### PR TITLE
fix(redis): pubsub 订阅独立连接池——WS 重连风暴不再抽干命令池打断流式回复

### DIFF
--- a/backend/api/routes/websocket.py
+++ b/backend/api/routes/websocket.py
@@ -188,7 +188,14 @@ class ConnectionManager:
                         self._remove_subscriber_task(session_id, ws, None)
                     if not active:
                         self._connections.pop(session_id, None)
-            await publish_session_message(session_id, payload)
+            # 跨 worker 扇出是尽力而为：publish 失败（如 Redis 池耗尽）只大声告警，
+            # 本地已 send 的帧不受影响，也不炸上游 fire-and-forget 事件任务。
+            try:
+                await publish_session_message(session_id, payload)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "ws_cross_worker_publish_degraded", session_id=session_id, error=str(exc)
+                )
         except Exception as exc:  # noqa: BLE001
             raise AgentError("WS_BROADCAST_ERROR", str(exc)) from exc
 

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -1,4 +1,4 @@
-from .redis_client import close_redis, get_redis, init_redis
+from .redis_client import close_redis, get_redis, get_redis_pubsub, init_redis
 from .settings import settings
 
-__all__ = ["close_redis", "get_redis", "init_redis", "settings"]
+__all__ = ["close_redis", "get_redis", "get_redis_pubsub", "init_redis", "settings"]

--- a/backend/config/redis_client.py
+++ b/backend/config/redis_client.py
@@ -17,15 +17,19 @@ except ModuleNotFoundError:
 _initialized_url: str | None = None
 _redis_client: Any | None = None
 _redis_pool: Any | None = None
+# pubsub 订阅专用客户端/池：Subscriber 按 WS 会话生命周期长期独占连接，
+# 与命令池隔离，防止订阅把命令池抽干导致 publish 报 MaxConnectionsError。
+_pubsub_client: Any | None = None
+_pubsub_pool: Any | None = None
 _init_lock: asyncio.Lock | None = None
 
 
-async def _create_redis_client(redis_url: str) -> tuple[Any, Any]:
+async def _create_redis_client(redis_url: str, max_connections: int) -> tuple[Any, Any]:
     if redis_asyncio is None:
         raise RuntimeError("redis package is not installed")
     pool = redis_asyncio.ConnectionPool.from_url(
         redis_url,
-        max_connections=20,
+        max_connections=max_connections,
         socket_timeout=5.0,
         socket_connect_timeout=5.0,
         retry_on_timeout=True,
@@ -37,7 +41,7 @@ async def _create_redis_client(redis_url: str) -> tuple[Any, Any]:
 
 
 async def init_redis() -> None:
-    global _initialized_url, _redis_client, _redis_pool
+    global _initialized_url, _redis_client, _redis_pool, _pubsub_client, _pubsub_pool
     redis_url = settings.redis_url.strip()
     if _initialized_url == redis_url and _redis_client is not None:
         return
@@ -49,17 +53,24 @@ async def init_redis() -> None:
         await _close_current()
         if not redis_url:
             raise AgentError("REDIS_URL_MISSING", "REDIS_URL must be set before initializing Redis.")
+        pool: Any | None = None
+        client: Any | None = None
         try:
-            pool, client = await _create_redis_client(redis_url)
+            pool, client = await _create_redis_client(redis_url, settings.redis_max_connections)
+            pubsub_pool, pubsub_client = await _create_redis_client(
+                redis_url, settings.redis_pubsub_max_connections
+            )
             logger.info("redis_initialized")
         except Exception as exc:
+            # 第二个池创建失败时回收第一个，不留半初始化状态。
+            await _close_pair(client, pool)
             _initialized_url = None
-            _redis_client = None
-            _redis_pool = None
             logger.exception("redis_init_failed")
             raise AgentError("REDIS_INIT_ERROR", str(exc)) from exc
         _redis_pool = pool
         _redis_client = client
+        _pubsub_pool = pubsub_pool
+        _pubsub_client = pubsub_client
         _initialized_url = redis_url
     finally:
         lock.release()
@@ -69,6 +80,13 @@ def get_redis() -> Any | None:
     if settings.redis_url.strip() != (_initialized_url or ""):
         return None
     return _redis_client
+
+
+def get_redis_pubsub() -> Any | None:
+    # 仅供长期订阅（Subscriber）使用；普通命令一律走 get_redis()。
+    if settings.redis_url.strip() != (_initialized_url or ""):
+        return None
+    return _pubsub_client
 
 
 async def close_redis() -> None:
@@ -82,11 +100,20 @@ async def close_redis() -> None:
 
 
 async def _close_current() -> None:
-    global _redis_client, _redis_pool
+    global _redis_client, _redis_pool, _pubsub_client, _pubsub_pool
     client = _redis_client
     pool = _redis_pool
+    pubsub_client = _pubsub_client
+    pubsub_pool = _pubsub_pool
     _redis_client = None
     _redis_pool = None
+    _pubsub_client = None
+    _pubsub_pool = None
+    await _close_pair(client, pool)
+    await _close_pair(pubsub_client, pubsub_pool)
+
+
+async def _close_pair(client: Any | None, pool: Any | None) -> None:
     if client is not None:
         try:
             await client.aclose()
@@ -111,4 +138,4 @@ async def _acquire_init_lock() -> asyncio.Lock:
     return _init_lock
 
 
-__all__ = ["close_redis", "get_redis", "init_redis"]
+__all__ = ["close_redis", "get_redis", "get_redis_pubsub", "init_redis"]

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -20,6 +20,11 @@ class Settings(BaseSettings):
     api_port: int = 8000
     database_url: str = ""
     redis_url: str = ""
+    # 命令池上限：publish/普通命令共用，须留足余量应对重连风暴（生产实证 20 会被抽干）。
+    redis_max_connections: int = Field(default=100, ge=1)
+    # pubsub 订阅池上限：每条活跃 WS 会话的 Subscriber 长期独占一条连接，
+    # 须大于单 worker 峰值并发 WS 数，且与命令池隔离防止互相饿死。
+    redis_pubsub_max_connections: int = Field(default=500, ge=1)
     database_pool_size: int = 5
     database_max_overflow: int = 10
     database_pool_timeout: int = 30

--- a/backend/core/pubsub.py
+++ b/backend/core/pubsub.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from backend.common.errors import AgentError
 from backend.common.logging import get_logger
-from backend.config import get_redis
+from backend.config import get_redis, get_redis_pubsub
 
 logger = get_logger(component="pubsub")
 
@@ -43,7 +43,8 @@ class Subscriber:
     async def subscribe(self, channel: str) -> None:
         try:
             if self._pubsub is None:
-                self._pubsub = _require_redis().pubsub()
+                # 订阅走独立 pubsub 池：连接按 WS 会话生命周期长期占用，不与 publish 抢命令池。
+                self._pubsub = _require_pubsub_redis().pubsub()
             await self._pubsub.subscribe(channel)
             self._channels.add(channel)
         except AgentError:
@@ -92,6 +93,13 @@ def _require_redis() -> Any:
     redis = get_redis()
     if redis is None:
         raise PubSubError("PUBSUB_REDIS_UNAVAILABLE", "Redis client is not initialized.")
+    return redis
+
+
+def _require_pubsub_redis() -> Any:
+    redis = get_redis_pubsub()
+    if redis is None:
+        raise PubSubError("PUBSUB_REDIS_UNAVAILABLE", "Redis pubsub client is not initialized.")
     return redis
 
 

--- a/backend/tests/unit/redis_test_support.py
+++ b/backend/tests/unit/redis_test_support.py
@@ -206,7 +206,9 @@ async def use_fake_redis(monkeypatch: Any, url: str = "redis://fake:6379/0") -> 
 
     fake = FakeRedisConnection()
 
-    async def _create_redis_client(_: str) -> tuple[FakeRedisPool, FakeAsyncRedis]:
+    # init_redis 会调两次（命令池 + pubsub 池），复用同一个 fake 客户端，
+    # 模拟同一台 Redis server 被两个池访问，保住 publish→subscribe round-trip 语义。
+    async def _create_redis_client(_: str, __: int) -> tuple[FakeRedisPool, FakeAsyncRedis]:
         return fake.pool, fake.client
 
     monkeypatch.setattr(redis_client, "_create_redis_client", _create_redis_client)

--- a/backend/tests/unit/test_pubsub.py
+++ b/backend/tests/unit/test_pubsub.py
@@ -5,10 +5,11 @@ import asyncio
 import pytest
 
 from backend.common.logging import get_worker_id
-from backend.core.pubsub import Subscriber, publish, ws_session_channel
+import backend.core.pubsub as pubsub_module
+from backend.core.pubsub import PubSubError, Subscriber, publish, ws_session_channel
 from backend.api.routes.websocket_pubsub import WebSocketEnvelope, forward_session_messages
 
-from .redis_test_support import use_fake_redis
+from .redis_test_support import FakeAsyncRedis, use_fake_redis
 
 
 class FakeWebSocket:
@@ -58,3 +59,32 @@ async def test_forward_session_messages_ignores_same_worker(monkeypatch: pytest.
     task.cancel()
     await task
     assert websocket.messages == [{"type": "message", "content": "remote"}]
+
+
+@pytest.mark.asyncio
+async def test_subscriber_uses_dedicated_pubsub_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 订阅连接长期占用，必须落在独立 pubsub 客户端上，不允许挤占命令池。
+    command_client = FakeAsyncRedis()
+    pubsub_client = FakeAsyncRedis()
+    monkeypatch.setattr(pubsub_module, "get_redis", lambda: command_client)
+    monkeypatch.setattr(pubsub_module, "get_redis_pubsub", lambda: pubsub_client)
+    subscriber = Subscriber(poll_timeout=0.05)
+    channel = ws_session_channel("session-3")
+    await subscriber.subscribe(channel)
+    assert channel in pubsub_client.subscribers
+    assert channel not in command_client.subscribers
+    await subscriber.unsubscribe()
+
+
+@pytest.mark.asyncio
+async def test_publish_raises_pubsub_error_when_pool_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 池耗尽（MaxConnectionsError 一类）在 publish 层的契约是抛 PubSubError，
+    # 降级（吞掉并告警）由 broadcast 负责，见 test_websocket_connection_manager。
+    fake = await use_fake_redis(monkeypatch)
+    fake.client.fail_operations.add("publish")
+    with pytest.raises(PubSubError, match="PUBSUB_PUBLISH_ERROR"):
+        await publish(ws_session_channel("session-4"), {"type": "message"})

--- a/backend/tests/unit/test_redis_client.py
+++ b/backend/tests/unit/test_redis_client.py
@@ -5,7 +5,7 @@ import logging
 import pytest
 
 from backend.common.errors import AgentError
-from backend.config import get_redis, init_redis
+from backend.config import get_redis, get_redis_pubsub, init_redis
 from backend.config.settings import settings
 
 import backend.config.redis_client as redis_client
@@ -29,7 +29,7 @@ async def test_init_redis_raises_when_connection_fails(
 ) -> None:
     settings.redis_url = "redis://nonexistent:6379/0"
 
-    async def _fail(_: str) -> tuple[object, object]:
+    async def _fail(_: str, __: int) -> tuple[object, object]:
         raise RuntimeError("boom")
 
     monkeypatch.setattr(redis_client, "_create_redis_client", _fail)
@@ -47,7 +47,7 @@ async def test_get_redis_returns_client_when_connected(
     fake_client = FakeAsyncRedis()
     fake_pool = FakeRedisPool()
 
-    async def _create(_: str) -> tuple[FakeRedisPool, FakeAsyncRedis]:
+    async def _create(_: str, __: int) -> tuple[FakeRedisPool, FakeAsyncRedis]:
         return fake_pool, fake_client
 
     monkeypatch.setattr(redis_client, "_create_redis_client", _create)
@@ -58,3 +58,60 @@ async def test_get_redis_returns_client_when_connected(
     await redis_client.close_redis()
     assert fake_client.closed is True
     assert fake_pool.disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_init_redis_creates_isolated_pubsub_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    created: list[tuple[int, FakeRedisPool, FakeAsyncRedis]] = []
+
+    async def _create(_: str, max_connections: int) -> tuple[FakeRedisPool, FakeAsyncRedis]:
+        pool, client = FakeRedisPool(), FakeAsyncRedis()
+        created.append((max_connections, pool, client))
+        return pool, client
+
+    monkeypatch.setattr(redis_client, "_create_redis_client", _create)
+    settings.redis_url = "redis://fake:6379/0"
+    await redis_client.close_redis()
+    await init_redis()
+
+    # 两个池按配置上限分别创建：命令池 + pubsub 订阅池，互相隔离。
+    assert [item[0] for item in created] == [
+        settings.redis_max_connections,
+        settings.redis_pubsub_max_connections,
+    ]
+    assert get_redis() is created[0][2]
+    assert get_redis_pubsub() is created[1][2]
+    assert get_redis() is not get_redis_pubsub()
+
+    await redis_client.close_redis()
+    assert all(client.closed for _, _, client in created)
+    assert all(pool.disconnected for _, pool, _ in created)
+    assert get_redis() is None
+    assert get_redis_pubsub() is None
+
+
+@pytest.mark.asyncio
+async def test_init_redis_cleans_up_when_pubsub_pool_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command_pool, command_client = FakeRedisPool(), FakeAsyncRedis()
+    calls = {"count": 0}
+
+    async def _create(_: str, __: int) -> tuple[FakeRedisPool, FakeAsyncRedis]:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return command_pool, command_client
+        raise RuntimeError("pubsub pool boom")
+
+    monkeypatch.setattr(redis_client, "_create_redis_client", _create)
+    settings.redis_url = "redis://fake:6379/0"
+    await redis_client.close_redis()
+    with pytest.raises(AgentError, match="REDIS_INIT_ERROR"):
+        await init_redis()
+    # 第二个池失败时第一个池必须被回收，不留半初始化状态。
+    assert get_redis() is None
+    assert get_redis_pubsub() is None
+    assert command_client.closed is True
+    assert command_pool.disconnected is True

--- a/backend/tests/unit/test_websocket_connection_manager.py
+++ b/backend/tests/unit/test_websocket_connection_manager.py
@@ -7,6 +7,7 @@ import pytest
 
 from backend.api.routes import websocket as websocket_route
 from backend.api.routes.websocket import ConnectionManager
+from backend.common.errors import AgentError
 
 
 class FakeWebSocket:
@@ -53,6 +54,27 @@ async def test_broadcast_reaches_all_session_connections(
         assert failed_task.cancelled()
     finally:
         failed_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_broadcast_survives_cross_worker_publish_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # 复盘 2026-07-13 生产事故：Redis 池耗尽时 publish 抛 MaxConnectionsError，
+    # 跨 worker 扇出失败只降级告警，本地已送达的流式帧与 WS 主链路不受连坐。
+    async def failing_publish(session_id: str, payload: dict[str, Any]) -> None:
+        raise AgentError("WS_PUBSUB_PUBLISH_ERROR", "Too many connections")
+
+    monkeypatch.setattr(websocket_route, "publish_session_message", failing_publish)
+    manager = ConnectionManager()
+    local = FakeWebSocket()
+    payload = {"type": "message", "content": "streamed"}
+
+    await manager.connect("session-1", local)  # type: ignore[arg-type]
+    await manager.broadcast("session-1", payload)  # 不应抛 WS_BROADCAST_ERROR
+
+    assert local.messages == [payload]
+    assert manager._connections["session-1"] == {local}  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景（生产实证 2026-07-13）

07:46 容器重启后客户端集中重连，07:52:48 出现 **18ms 内 11 次 `MaxConnectionsError("Too many connections")`**，一次正在流式回传的聊天回复帧发不出去（`pubsub_publish_failed` + `agent_event_handler_failed`）。

根因：`backend/config/redis_client.py` 单池 `max_connections=20`，而每条活跃 WS 会话经 `forward_session_messages` → `Subscriber` **长期独占**一条 pubsub 连接，publish 与 subscribe 共池——订阅数逼近 20 时 publish 拿不到连接。Redis 服务端本身无压力（maxclients 10000、rejected 0），瓶颈纯在应用侧池上限。

## 改动

| 层 | 改动 |
|---|---|
| `config/settings.py` | 新增 `REDIS_MAX_CONNECTIONS`（默认 100）、`REDIS_PUBSUB_MAX_CONNECTIONS`（默认 500，须 > 单 worker 峰值并发 WS 数） |
| `config/redis_client.py` | 双池：命令池 + pubsub 订阅独立池，新增 `get_redis_pubsub()`；第二池初始化失败回收第一池，不留半初始化状态 |
| `core/pubsub.py` | `Subscriber.subscribe` 走独立 pubsub 池；`publish` 契约不变（失败仍抛 `PubSubError`） |
| `api/routes/websocket.py` | `broadcast` 跨 worker 扇出降级：publish 失败只告警 `ws_cross_worker_publish_degraded`，本地已送达帧与上游 fire-and-forget 事件任务不受连坐 |

## 测试

- 新增 5 个用例：双池创建/关闭生命周期、pubsub 池初始化失败清理、Subscriber 落专用客户端、publish 池耗尽抛错契约、**broadcast 降级不炸 WS 主链路**（直接复盘本次事故场景）
- 全量单测：**1489 passed, 90 skipped**；唯一失败 `test_x_api.py::test_upstream_error_is_502` 在干净基线（bd1ac72）全量跑同样失败、隔离跑通过——先前就存在的顺序性 flake，与本 PR 无关

🤖 Generated with [Claude Code](https://claude.com/claude-code)